### PR TITLE
Refactor error types

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 
+pub const API_NAME: &'static str = "VTubeStudioPublicAPI";
+pub const API_VERSION: &'static str = "1.0";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestEnvelope {
@@ -13,6 +16,17 @@ pub struct RequestEnvelope {
     pub request_id: Option<String>,
     #[serde(flatten)]
     pub data: RequestData,
+}
+
+impl RequestEnvelope {
+    pub fn new(data: RequestData) -> Self {
+        Self {
+            api_name: Cow::Borrowed(API_NAME),
+            api_version: Cow::Borrowed(API_VERSION),
+            request_id: None,
+            data,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,23 @@
-use crate::client::IdTagger;
-use crate::data::{ApiError, RequestEnvelope, ResponseData};
-use crate::transport::{ApiTransport, WebSocketTransport};
-use tokio_tower::multiplex::MultiplexTransport;
+use crate::data::{ApiError, ResponseData};
 
+use futures_core::TryStream;
+use futures_sink::Sink;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum Error<T: WebSocketTransport> {
-    #[error("transport error")]
-    Transport(#[from] TransportError<T::StreamError, T::SinkError>),
-    #[error("transport error")]
-    Multiplex(
-        #[from] tokio_tower::Error<MultiplexTransport<ApiTransport<T>, IdTagger>, RequestEnvelope>,
-    ),
+pub enum Error<R, W> {
+    #[error("underlying transport failed while attempting to receive a response")]
+    Read(R),
+    #[error("underlying transport failed to send a request")]
+    Write(W),
+    #[error("failed to parse JSON")]
+    Json(#[from] serde_json::Error),
+    #[error("no more in-flight requests allowed")]
+    TransportFull,
+    #[error("connection was dropped")]
+    ConnectionDropped,
+    #[error("received server response with unexpected request ID")]
+    Desynchronized,
     #[error("received APIError {}: {}", .0.error_id, .0.message)]
     Api(ApiError),
     #[error("received unexpected response (expected {expected}, received {received:?})")]
@@ -23,16 +28,33 @@ pub enum Error<T: WebSocketTransport> {
 }
 
 #[derive(Error, Debug)]
-pub enum TransportError<R, W> {
+pub enum TransportError<E> {
+    #[error("underlying transport failed")]
+    Underlying(E),
     #[error("failed to parse JSON")]
     Json(#[from] serde_json::Error),
-    #[error("read error")]
-    Read(R),
-    #[error("write error")]
-    Write(W),
 }
 
-impl<T: WebSocketTransport> Error<T> {
+impl<T, I, R, W> From<tokio_tower::Error<T, I>> for Error<R, W>
+where
+    T: Sink<I, Error = TransportError<W>> + TryStream<Error = TransportError<R>>,
+{
+    fn from(error: tokio_tower::Error<T, I>) -> Self {
+        use tokio_tower::Error::*;
+
+        match error {
+            BrokenTransportSend(TransportError::Underlying(e)) => Error::Write(e),
+            BrokenTransportSend(TransportError::Json(e)) => Error::Json(e),
+            BrokenTransportRecv(Some(TransportError::Underlying(e))) => Error::Read(e),
+            BrokenTransportRecv(Some(TransportError::Json(e))) => Error::Json(e),
+            BrokenTransportRecv(None) | ClientDropped => Error::ConnectionDropped,
+            TransportFull => Error::TransportFull,
+            Desynchronized => Error::Desynchronized,
+        }
+    }
+}
+
+impl<R, W> Error<R, W> {
     pub fn is_auth_error(&self) -> bool {
         matches!(self, Error::Api(e) if e.is_auth_error())
     }


### PR DESCRIPTION
`Error` takes two error types as type params, rather than a unified
stream/sink type. this should make it easier to specify the concrete
type in application code.