### PR TITLE
Ignore tungstenite examples if feature disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,16 @@ jobs:
         toolchain: 1.56.1
         override: true
     - uses: Swatinem/rust-cache@v1.3.0
-    - uses: actions-rs/cargo@v1
+    - name: test --all-features
+      uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all --verbose
+        args: --all-features --verbose
+    - name: test --no-default-features
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --no-default-features --verbose
     - name: Check for uncommitted changes
       shell: bash
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ description = "A library for interacting with the VTube Studio API."
 [features]
 default = ["tokio-tungstenite"]
 
+[[example]]
+name = "statistics"
+required-features = ["tokio-tungstenite"]
+
 [dependencies]
 displaydoc = "0.2"
 futures-core = "0.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -43,9 +43,11 @@ impl Client<CloneBoxApiService> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    #[cfg_attr(feature = "tokio-tungstenite", doc = "```no_run")]
+    #[cfg_attr(not(feature = "tokio-tungstenite"), doc = "```ignore")]
     /// # use vtubestudio::Client;
     /// let (mut client, mut new_tokens) = Client::builder()
+    ///     .with_token(Some("...".to_string()))
     ///     .authentication("Plugin name", "Developer name", None)
     ///     .build_tungstenite();
     /// ```
@@ -74,7 +76,8 @@ where
     ///
     /// # Example
     ///
-    /// ```no_run
+    #[cfg_attr(feature = "tokio-tungstenite", doc = "```no_run")]
+    #[cfg_attr(not(feature = "tokio-tungstenite"), doc = "```ignore")]
     /// # async fn run() -> Result<(), vtubestudio::error::BoxError> {
     /// # use vtubestudio::Client;
     /// use vtubestudio::data::StatisticsRequest;
@@ -98,7 +101,8 @@ where
 ///
 /// # Example
 ///
-/// ```no_run
+#[cfg_attr(feature = "tokio-tungstenite", doc = "```no_run")]
+#[cfg_attr(not(feature = "tokio-tungstenite"), doc = "```ignore")]
 /// # async fn run() -> Result<(), vtubestudio::error::BoxError> {
 /// # fn do_something_with_new_token(token: String) { unimplemented!(); }
 /// # use vtubestudio::Client;
@@ -155,7 +159,8 @@ impl TokenReceiver {
     ///
     /// # Example
     ///
-    /// ```no_run
+    #[cfg_attr(feature = "tokio-tungstenite", doc = "```no_run")]
+    #[cfg_attr(not(feature = "tokio-tungstenite"), doc = "```ignore")]
     /// # async fn run() -> Result<(), vtubestudio::error::BoxError> {
     /// # fn do_something_with_new_token(token: String) { unimplemented!(); }
     /// # use vtubestudio::Client;

--- a/src/client.rs
+++ b/src/client.rs
@@ -47,7 +47,7 @@ impl Client<CloneBoxApiService> {
     #[cfg_attr(not(feature = "tokio-tungstenite"), doc = "```ignore")]
     /// # use vtubestudio::Client;
     /// let (mut client, mut new_tokens) = Client::builder()
-    ///     .with_token(Some("...".to_string()))
+    ///     .auth_token(Some("...".to_string()))
     ///     .authentication("Plugin name", "Developer name", None)
     ///     .build_tungstenite();
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@
 //! * requests a new auth token on receiving an auth error, and retries the initial failed
 //!   request on authentication success
 //!
-//! ```no_run
+#![cfg_attr(feature = "tokio-tungstenite", doc = "```no_run")]
+#![cfg_attr(not(feature = "tokio-tungstenite"), doc = "```ignore")]
 //! use vtubestudio::{Client, Error};
 //! use vtubestudio::data::StatisticsRequest;
 //!


### PR DESCRIPTION
If `--no-default-features` is specified, this will avoid running the
tungstenite-specific examples on test. Also adds a step to CI to make
sure the tests pass in both cases (all features and no features).

https://stackoverflow.com/a/69420214