### PR TITLE
Use enums for `message_type` field

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -171,42 +171,49 @@ macro_rules! first_expr {
     };
 }
 
-impl fmt::Display for MessageType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl Serialize for MessageType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl From<String> for MessageType {
-    fn from(string: String) -> Self {
-        Self::from_known_type(string.as_ref()).unwrap_or_else(|| Self::Other(string.into()))
-    }
-}
-
-impl MessageType {
-    fn is_other(&self) -> bool {
-        matches!(self, Self::Other(_))
-    }
-}
-
-impl PartialEq for MessageType {
-    fn eq(&self, rhs: &Self) -> bool {
-        if self.is_other() || rhs.is_other() {
-            self.as_str() == rhs.as_str()
-        } else {
-            std::mem::discriminant(self) == std::mem::discriminant(rhs)
+macro_rules! impl_msg_type {
+    ($name:ident) => {
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.as_str())
+            }
         }
-    }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.collect_str(self)
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(string: String) -> Self {
+                Self::from_known_type(string.as_ref()).unwrap_or_else(|| Self::Other(string.into()))
+            }
+        }
+
+        impl $name {
+            fn is_other(&self) -> bool {
+                matches!(self, Self::Other(_))
+            }
+        }
+
+        impl PartialEq for $name {
+            fn eq(&self, rhs: &Self) -> bool {
+                if self.is_other() || rhs.is_other() {
+                    self.as_str() == rhs.as_str()
+                } else {
+                    std::mem::discriminant(self) == std::mem::discriminant(rhs)
+                }
+            }
+        }
+    };
 }
+
+impl_msg_type!(RequestType);
+impl_msg_type!(ResponseType);
 
 macro_rules! define_request_response_pairs {
     ($({
@@ -217,36 +224,103 @@ macro_rules! define_request_response_pairs {
         resp = $(( $resp_inner:ident ))? $({ $($resp_fields:tt)* })?,
     },)*) => {
         paste! {
+            /// The message type of the [`RequestEnvelope`].
             #[allow(missing_docs)]
             #[derive(Debug, Clone, Deserialize)]
             #[serde(from = "String")]
-            pub enum MessageType {
-                #[serde(rename = "APIError")]
-                ApiError,
-                #[serde(rename = "VTubeStudioAPIStateBroadcast")]
-                VTubeStudioApiStateBroadcast,
+            pub enum RequestType {
                 $(
-                        $(#[serde(rename = $req_name)])?
-                        [<$rust_name Request>],
-                        $(#[serde(rename = $resp_name)])?
-                        [<$rust_name Response>],
+                    $(#[serde(rename = $req_name)])?
+                    [<$rust_name Request>],
                 )*
                 Other(Cow<'static, str>),
             }
 
-            impl MessageType {
-                /// Returns the string representation of this message type.
+            /// The message type of the [`ResponseEnvelope`].
+            #[allow(missing_docs)]
+            #[derive(Debug, Clone, Deserialize)]
+            #[serde(from = "String")]
+            pub enum ResponseType {
+                #[serde(rename = "APIError")]
+                ApiError,
+                $(
+                    $(#[serde(rename = $resp_name)])?
+                    [<$rust_name Response>],
+                )*
+                #[serde(rename = "VTubeStudioAPIStateBroadcast")]
+                VTubeStudioApiStateBroadcast,
+                Other(Cow<'static, str>),
+            }
+
+            impl RequestType {
+                /// Returns the string representation of this request type.
                 ///
                 /// ```
-                /// # use vtubestudio::data::MessageType;
+                /// # use vtubestudio::data::RequestType;
                 /// assert_eq!(
-                ///     MessageType::StatisticsRequest.as_str(),
+                ///     RequestType::StatisticsRequest.as_str(),
                 ///     "StatisticsRequest"
                 /// );
                 ///
                 /// assert_eq!(
-                ///     MessageType::Other("SomethingElse".into()).as_str(),
+                ///     RequestType::Other("SomethingElse".into()).as_str(),
                 ///     "SomethingElse"
+                /// );
+                /// ```
+                pub fn as_str(&self) -> &str {
+                    match self {
+                        $(
+                            Self::[<$rust_name Request>] => first_expr![
+                                $($req_name,)?
+                                concat!(stringify!($rust_name), "Request")
+                            ],
+                        )*
+                        Self::Other(value) => &value,
+                    }
+                }
+
+                /// Returns the request type if it's type known to this library.
+                ///
+                /// ```
+                /// # use vtubestudio::data::RequestType;
+                /// assert!(
+                ///     matches!(
+                ///         RequestType::from_known_type("StatisticsRequest"),
+                ///         Some(RequestType::StatisticsRequest)
+                ///     )
+                /// );
+                ///
+                /// assert!(RequestType::from_known_type("SomeOtherRequest").is_none());
+                /// ```
+                pub fn from_known_type(name: &str) -> Option<Self> {
+                    Some(match name {
+                        $(
+                            first_expr![
+                                $($req_name,)?
+                                concat!(stringify!($rust_name), "Request")
+                            ] => Self::[<$rust_name Request>],
+                        )*
+                        _ => return None,
+                    })
+                }
+
+            }
+
+
+
+            impl ResponseType {
+                /// Returns the string representation of this response type.
+                ///
+                /// ```
+                /// # use vtubestudio::data::ResponseType;
+                /// assert_eq!(
+                ///     ResponseType::StatisticsResponse.as_str(),
+                ///     "StatisticsResponse"
+                /// );
+                ///
+                /// assert_eq!(
+                ///     ResponseType::Other("SomeNewlyAddedResponseType".into()).as_str(),
+                ///     "SomeNewlyAddedResponseType"
                 /// );
                 /// ```
                 pub fn as_str(&self) -> &str {
@@ -260,30 +334,23 @@ macro_rules! define_request_response_pairs {
                             ],
                         )*
 
-                        $(
-                            Self::[<$rust_name Request>] => first_expr![
-                                $($req_name,)?
-                                concat!(stringify!($rust_name), "Request")
-                            ],
-                        )*
-
                         Self::VTubeStudioApiStateBroadcast => "VTubeStudioAPIStateBroadcast",
                         Self::Other(value) => &value,
                     }
                 }
 
-                /// Returns the message type if it's type known to this library.
+                /// Returns the response type if it's type known to this library.
                 ///
                 /// ```
-                /// # use vtubestudio::data::MessageType;
+                /// # use vtubestudio::data::ResponseType;
                 /// assert!(
                 ///     matches!(
-                ///         MessageType::from_known_type("StatisticsRequest"),
-                ///         Some(MessageType::StatisticsRequest)
+                ///         ResponseType::from_known_type("StatisticsResponse"),
+                ///         Some(ResponseType::StatisticsResponse)
                 ///     )
                 /// );
                 ///
-                /// assert!(MessageType::from_known_type("Something").is_none());
+                /// assert!(ResponseType::from_known_type("SomeOtherResponse").is_none());
                 /// ```
                 pub fn from_known_type(name: &str) -> Option<Self> {
                     Some(match name {
@@ -294,17 +361,10 @@ macro_rules! define_request_response_pairs {
                                 concat!(stringify!($rust_name), "Response")
                             ] => Self::[<$rust_name Response>],
                         )*
-                        $(
-                            first_expr![
-                                $($req_name,)?
-                                concat!(stringify!($rust_name), "Request")
-                            ] => Self::[<$rust_name Request>],
-                        )*
                         "VTubeStudioAPIStateBroadcast" => Self::VTubeStudioApiStateBroadcast,
                         _ => return None,
                     })
                 }
-
             }
 
         }
@@ -769,59 +829,84 @@ mod tests {
     type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
     #[test]
-    fn message_type_eq() -> Result {
+    fn request_type_eq() -> Result {
         assert_eq!(
-            MessageType::VtsFolderInfoRequest,
-            MessageType::VtsFolderInfoRequest,
+            RequestType::VtsFolderInfoRequest,
+            RequestType::VtsFolderInfoRequest,
         );
 
         assert_eq!(
-            MessageType::VtsFolderInfoRequest,
-            MessageType::Other("VTSFolderInfoRequest".into()),
+            RequestType::VtsFolderInfoRequest,
+            RequestType::Other("VTSFolderInfoRequest".into()),
         );
 
         assert_eq!(
-            MessageType::Other("VTSFolderInfoRequest".into()),
-            MessageType::VtsFolderInfoRequest,
+            RequestType::Other("VTSFolderInfoRequest".into()),
+            RequestType::VtsFolderInfoRequest,
         );
 
         assert_eq!(
-            MessageType::Other("VTSFolderInfoRequest".into()),
-            MessageType::Other("VTSFolderInfoRequest".into()),
+            RequestType::Other("VTSFolderInfoRequest".into()),
+            RequestType::Other("VTSFolderInfoRequest".into()),
         );
 
         Ok(())
     }
 
     #[test]
-    fn message_type_json() -> Result {
+    fn response_type_eq() -> Result {
+        assert_eq!(
+            ResponseType::VtsFolderInfoResponse,
+            ResponseType::VtsFolderInfoResponse,
+        );
+
+        assert_eq!(
+            ResponseType::VtsFolderInfoResponse,
+            ResponseType::Other("VTSFolderInfoResponse".into()),
+        );
+
+        assert_eq!(
+            ResponseType::Other("VTSFolderInfoResponse".into()),
+            ResponseType::VtsFolderInfoResponse,
+        );
+
+        assert_eq!(
+            ResponseType::Other("VTSFolderInfoResponse".into()),
+            ResponseType::Other("VTSFolderInfoResponse".into()),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn response_type_json() -> Result {
         assert!(matches!(
-            serde_json::from_value::<MessageType>(json!("APIError"))?,
-            MessageType::ApiError,
+            serde_json::from_value::<ResponseType>(json!("APIError"))?,
+            ResponseType::ApiError,
         ));
 
         assert_eq!(
-            serde_json::to_value::<MessageType>(MessageType::ApiError)?,
+            serde_json::to_value::<ResponseType>(ResponseType::ApiError)?,
             json!("APIError"),
         );
 
         assert!(matches!(
-            serde_json::from_value::<MessageType>(json!("ColorTintResponse"))?,
-            MessageType::ColorTintResponse,
+            serde_json::from_value::<ResponseType>(json!("ColorTintResponse"))?,
+            ResponseType::ColorTintResponse,
         ));
 
         assert_eq!(
-            serde_json::to_value::<MessageType>(MessageType::ColorTintResponse)?,
+            serde_json::to_value::<ResponseType>(ResponseType::ColorTintResponse)?,
             json!("ColorTintResponse"),
         );
 
         assert!(matches!(
-            serde_json::from_value::<MessageType>(json!("WalfieResponse"))?,
-            MessageType::Other(resp) if resp == "WalfieResponse",
+            serde_json::from_value::<ResponseType>(json!("WalfieResponse"))?,
+            ResponseType::Other(resp) if resp == "WalfieResponse",
         ));
 
         assert_eq!(
-            serde_json::to_value::<MessageType>(MessageType::Other("WalfieResponse".into()))?,
+            serde_json::to_value::<ResponseType>(ResponseType::Other("WalfieResponse".into()))?,
             json!("WalfieResponse"),
         );
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use futures_core::TryStream;
 use futures_sink::Sink;
 use std::error::Error as StdError;
 
-pub use crate::data::ApiError;
+pub use crate::data::{ApiError, ResponseType};
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn StdError + Send + Sync>;
@@ -49,9 +49,9 @@ pub enum ErrorKind {
 #[error("received unexpected response (expected {expected}, received {received})")]
 pub struct UnexpectedResponseError {
     /// The expected response type.
-    pub expected: &'static str,
+    pub expected: ResponseType,
     /// The received response type.
-    pub received: String,
+    pub received: ResponseType,
 }
 
 impl From<serde_json::Error> for Error {


### PR DESCRIPTION
Rather than accepting a raw string for the message types, this PR
updates it to use `RequestType` and `ResponseType` enums, with an
escape hatch for other types (e.g., if new response types are added to
the API, users can update their code to expect it, without needing to
wait for this library to be updated first)