### PR TITLE
Refactor request/response type enums

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -2,16 +2,57 @@ use crate::error::{Error, UnexpectedResponseError};
 
 use paste::paste;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::borrow::Cow;
-use std::fmt;
 
 /// The default `api_name` value in requests and responses.
 pub const API_NAME: &'static str = "VTubeStudioPublicAPI";
 
 /// The default `api_version` value in requests and responses.
 pub const API_VERSION: &'static str = "1.0";
+
+crate::enumeration::define_string_enum!(
+    /// Message type for [`RequestEnvelope`].
+    ///
+    /// This is an opaque value rather than a plain `enum`, to allow the user to specify variants
+    /// besides the ones defined in this library (E.g., when a new API request is supported but
+    /// hasn't been added to this library yet).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use vtubestudio::data::{KnownRequestType, RequestType};
+    ///
+    /// assert_eq!(
+    ///     RequestType::new(KnownRequestType::ApiStateRequest),
+    ///     RequestType::new_from_str("APIStateRequest"),
+    /// );
+    /// ```
+    RequestType,
+    KnownRequestType
+);
+
+crate::enumeration::define_string_enum!(
+    /// Message type for [`ResponseEnvelope`].
+    ///
+    /// This is an opaque value rather than a plain `enum`, to allow the user to specify variants
+    /// besides the ones defined in this library (E.g., when a new API response is supported but
+    /// hasn't been added to this library yet).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use vtubestudio::data::{KnownResponseType, ResponseType};
+    ///
+    /// assert_eq!(
+    ///     ResponseType::new(KnownResponseType::ApiStateResponse),
+    ///     ResponseType::new_from_str("APIStateResponse"),
+    /// );
+    /// ```
+    ResponseType,
+    KnownResponseType
+);
 
 /// A VTube Studio API request.
 #[allow(missing_docs)]
@@ -31,7 +72,7 @@ impl Default for RequestEnvelope {
         Self {
             api_name: Cow::Borrowed(API_NAME),
             api_version: Cow::Borrowed(API_VERSION),
-            message_type: RequestType::ApiStateRequest,
+            message_type: KnownRequestType::ApiStateRequest.into(),
             request_id: None,
             data: Value::Null,
         }
@@ -80,7 +121,7 @@ impl Default for ResponseEnvelope {
         Self {
             api_name: API_NAME.to_owned(),
             api_version: API_VERSION.to_owned(),
-            message_type: ResponseType::Other("UnknownResponse".into()),
+            message_type: ResponseType::const_new_from_str("UnknownResponse"),
             timestamp: 0,
             request_id: "".to_owned(),
             data: Value::Null,
@@ -162,59 +203,6 @@ pub trait Response: DeserializeOwned + Send + 'static {
     const MESSAGE_TYPE: ResponseType;
 }
 
-macro_rules! first_expr {
-    ($value:expr) => {
-        $value
-    };
-    ($value:expr, $_:expr) => {
-        $value
-    };
-}
-
-macro_rules! impl_msg_type {
-    ($name:ident) => {
-        impl fmt::Display for $name {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{}", self.as_str())
-            }
-        }
-
-        impl Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
-            {
-                serializer.collect_str(self)
-            }
-        }
-
-        impl From<String> for $name {
-            fn from(string: String) -> Self {
-                Self::from_known_type(string.as_ref()).unwrap_or_else(|| Self::Other(string.into()))
-            }
-        }
-
-        impl $name {
-            fn is_other(&self) -> bool {
-                matches!(self, Self::Other(_))
-            }
-        }
-
-        impl PartialEq for $name {
-            fn eq(&self, rhs: &Self) -> bool {
-                if self.is_other() || rhs.is_other() {
-                    self.as_str() == rhs.as_str()
-                } else {
-                    std::mem::discriminant(self) == std::mem::discriminant(rhs)
-                }
-            }
-        }
-    };
-}
-
-impl_msg_type!(RequestType);
-impl_msg_type!(ResponseType);
-
 macro_rules! define_request_response_pairs {
     ($({
         rust_name = $rust_name:ident,
@@ -224,23 +212,22 @@ macro_rules! define_request_response_pairs {
         resp = $(( $resp_inner:ident ))? $({ $($resp_fields:tt)* })?,
     },)*) => {
         paste! {
-            /// The message type of the [`RequestEnvelope`].
+            /// Known message types for [`RequestType`].
             #[allow(missing_docs)]
-            #[derive(Debug, Clone, Deserialize)]
-            #[serde(from = "String")]
-            pub enum RequestType {
+            #[non_exhaustive]
+            #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+            pub enum KnownRequestType {
                 $(
                     $(#[serde(rename = $req_name)])?
                     [<$rust_name Request>],
                 )*
-                Other(Cow<'static, str>),
             }
 
-            /// The message type of the [`ResponseEnvelope`].
+            /// Known message types for [`ResponseType`].
             #[allow(missing_docs)]
-            #[derive(Debug, Clone, Deserialize)]
-            #[serde(from = "String")]
-            pub enum ResponseType {
+            #[non_exhaustive]
+            #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+            pub enum KnownResponseType {
                 #[serde(rename = "APIError")]
                 ApiError,
                 $(
@@ -249,124 +236,7 @@ macro_rules! define_request_response_pairs {
                 )*
                 #[serde(rename = "VTubeStudioAPIStateBroadcast")]
                 VTubeStudioApiStateBroadcast,
-                Other(Cow<'static, str>),
             }
-
-            impl RequestType {
-                /// Returns the string representation of this request type.
-                ///
-                /// ```
-                /// # use vtubestudio::data::RequestType;
-                /// assert_eq!(
-                ///     RequestType::StatisticsRequest.as_str(),
-                ///     "StatisticsRequest"
-                /// );
-                ///
-                /// assert_eq!(
-                ///     RequestType::Other("SomethingElse".into()).as_str(),
-                ///     "SomethingElse"
-                /// );
-                /// ```
-                pub fn as_str(&self) -> &str {
-                    match self {
-                        $(
-                            Self::[<$rust_name Request>] => first_expr![
-                                $($req_name,)?
-                                concat!(stringify!($rust_name), "Request")
-                            ],
-                        )*
-                        Self::Other(value) => &value,
-                    }
-                }
-
-                /// Returns the request type if it's type known to this library.
-                ///
-                /// ```
-                /// # use vtubestudio::data::RequestType;
-                /// assert!(
-                ///     matches!(
-                ///         RequestType::from_known_type("StatisticsRequest"),
-                ///         Some(RequestType::StatisticsRequest)
-                ///     )
-                /// );
-                ///
-                /// assert!(RequestType::from_known_type("SomeOtherRequest").is_none());
-                /// ```
-                pub fn from_known_type(name: &str) -> Option<Self> {
-                    Some(match name {
-                        $(
-                            first_expr![
-                                $($req_name,)?
-                                concat!(stringify!($rust_name), "Request")
-                            ] => Self::[<$rust_name Request>],
-                        )*
-                        _ => return None,
-                    })
-                }
-
-            }
-
-
-
-            impl ResponseType {
-                /// Returns the string representation of this response type.
-                ///
-                /// ```
-                /// # use vtubestudio::data::ResponseType;
-                /// assert_eq!(
-                ///     ResponseType::StatisticsResponse.as_str(),
-                ///     "StatisticsResponse"
-                /// );
-                ///
-                /// assert_eq!(
-                ///     ResponseType::Other("SomeNewlyAddedResponseType".into()).as_str(),
-                ///     "SomeNewlyAddedResponseType"
-                /// );
-                /// ```
-                pub fn as_str(&self) -> &str {
-                    match self {
-                        Self::ApiError => "APIError",
-
-                        $(
-                            Self::[<$rust_name Response>] => first_expr![
-                                $($resp_name,)?
-                                concat!(stringify!($rust_name), "Response")
-                            ],
-                        )*
-
-                        Self::VTubeStudioApiStateBroadcast => "VTubeStudioAPIStateBroadcast",
-                        Self::Other(value) => &value,
-                    }
-                }
-
-                /// Returns the response type if it's type known to this library.
-                ///
-                /// ```
-                /// # use vtubestudio::data::ResponseType;
-                /// assert!(
-                ///     matches!(
-                ///         ResponseType::from_known_type("StatisticsResponse"),
-                ///         Some(ResponseType::StatisticsResponse)
-                ///     )
-                /// );
-                ///
-                /// assert!(ResponseType::from_known_type("SomeOtherResponse").is_none());
-                /// ```
-                pub fn from_known_type(name: &str) -> Option<Self> {
-                    Some(match name {
-                        "APIError" => Self::ApiError,
-                        $(
-                            first_expr![
-                                $($resp_name,)?
-                                concat!(stringify!($rust_name), "Response")
-                            ] => Self::[<$rust_name Response>],
-                        )*
-                        "VTubeStudioAPIStateBroadcast" => Self::VTubeStudioApiStateBroadcast,
-                        _ => return None,
-                    })
-                }
-            }
-
         }
 
         $(
@@ -378,7 +248,7 @@ macro_rules! define_request_response_pairs {
 
                 impl Request for [<$rust_name Request>] {
                     type Response = [<$rust_name Response>];
-                    const MESSAGE_TYPE: RequestType = RequestType::[<$rust_name Request>];
+                    const MESSAGE_TYPE: RequestType = RequestType::new(KnownRequestType::[<$rust_name Request>]);
                 }
 
                 #[allow(missing_docs)]
@@ -387,7 +257,7 @@ macro_rules! define_request_response_pairs {
                 pub struct [<$rust_name Response>] $(($resp_inner);)? $({ $($resp_fields)* })?
 
                 impl Response for [<$rust_name Response>] {
-                    const MESSAGE_TYPE: ResponseType = ResponseType::[<$rust_name Response>];
+                    const MESSAGE_TYPE: ResponseType = ResponseType::new(KnownResponseType::[<$rust_name Response>]);
                 }
             }
         )*
@@ -686,7 +556,7 @@ pub struct ApiError {
 }
 
 impl Response for ApiError {
-    const MESSAGE_TYPE: ResponseType = ResponseType::ApiError;
+    const MESSAGE_TYPE: ResponseType = ResponseType::new(KnownResponseType::ApiError);
 }
 
 impl ApiError {
@@ -708,7 +578,8 @@ pub struct VTubeStudioApiStateBroadcast {
 }
 
 impl Response for VTubeStudioApiStateBroadcast {
-    const MESSAGE_TYPE: ResponseType = ResponseType::VTubeStudioApiStateBroadcast;
+    const MESSAGE_TYPE: ResponseType =
+        ResponseType::new(KnownResponseType::VTubeStudioApiStateBroadcast);
 }
 
 #[allow(missing_docs)]
@@ -823,84 +694,34 @@ mod tests {
     type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
     #[test]
-    fn request_type_eq() -> Result {
-        assert_eq!(
-            RequestType::VtsFolderInfoRequest,
-            RequestType::VtsFolderInfoRequest,
-        );
-
-        assert_eq!(
-            RequestType::VtsFolderInfoRequest,
-            RequestType::Other("VTSFolderInfoRequest".into()),
-        );
-
-        assert_eq!(
-            RequestType::Other("VTSFolderInfoRequest".into()),
-            RequestType::VtsFolderInfoRequest,
-        );
-
-        assert_eq!(
-            RequestType::Other("VTSFolderInfoRequest".into()),
-            RequestType::Other("VTSFolderInfoRequest".into()),
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn response_type_eq() -> Result {
-        assert_eq!(
-            ResponseType::VtsFolderInfoResponse,
-            ResponseType::VtsFolderInfoResponse,
-        );
-
-        assert_eq!(
-            ResponseType::VtsFolderInfoResponse,
-            ResponseType::Other("VTSFolderInfoResponse".into()),
-        );
-
-        assert_eq!(
-            ResponseType::Other("VTSFolderInfoResponse".into()),
-            ResponseType::VtsFolderInfoResponse,
-        );
-
-        assert_eq!(
-            ResponseType::Other("VTSFolderInfoResponse".into()),
-            ResponseType::Other("VTSFolderInfoResponse".into()),
-        );
-
-        Ok(())
-    }
-
-    #[test]
     fn response_type_json() -> Result {
-        assert!(matches!(
+        assert_eq!(
             serde_json::from_value::<ResponseType>(json!("APIError"))?,
-            ResponseType::ApiError,
-        ));
+            ResponseType::new(KnownResponseType::ApiError),
+        );
 
         assert_eq!(
-            serde_json::to_value::<ResponseType>(ResponseType::ApiError)?,
+            serde_json::to_value::<ResponseType>(ResponseType::new(KnownResponseType::ApiError))?,
             json!("APIError"),
         );
 
-        assert!(matches!(
+        assert_eq!(
             serde_json::from_value::<ResponseType>(json!("ColorTintResponse"))?,
-            ResponseType::ColorTintResponse,
-        ));
+            KnownResponseType::ColorTintResponse,
+        );
 
         assert_eq!(
-            serde_json::to_value::<ResponseType>(ResponseType::ColorTintResponse)?,
+            serde_json::to_value::<ResponseType>(KnownResponseType::ColorTintResponse.into())?,
             json!("ColorTintResponse"),
         );
 
-        assert!(matches!(
+        assert_eq!(
             serde_json::from_value::<ResponseType>(json!("WalfieResponse"))?,
-            ResponseType::Other(resp) if resp == "WalfieResponse",
-        ));
+            ResponseType::new_from_str("WalfieResponse"),
+        );
 
         assert_eq!(
-            serde_json::to_value::<ResponseType>(ResponseType::Other("WalfieResponse".into()))?,
+            serde_json::to_value(ResponseType::new_from_str("WalfieResponse"))?,
             json!("WalfieResponse"),
         );
 

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -1,0 +1,469 @@
+use serde::ser::{Impossible, SerializeTupleVariant};
+use serde::{Deserialize, Serialize, Serializer};
+use std::borrow::Cow;
+
+macro_rules! define_string_enum {
+    ($name:ident, $type:ty) => {
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+        pub struct $name(crate::enumeration::StringEnum<$type>);
+
+        impl $name {
+            /// Returns the string representation.
+            pub fn as_str(&self) -> &str {
+                self.0.as_str()
+            }
+
+            /// Creates a new value from a known variant.
+            pub fn new(variant: $type) -> Self {
+                Self(crate::enumeration::StringEnum::new(variant))
+            }
+
+            /// Creates a new value from a raw string.
+            pub fn new_from_str<S>(value: S) -> Self
+            where
+                S: Into<Cow<'static, str>>,
+            {
+                Self(crate::enumeration::StringEnum::new_from_str(value))
+            }
+        }
+
+        impl From<$type> for $name {
+            fn from(value: $type) -> Self {
+                Self::new(value)
+            }
+        }
+
+        impl PartialEq<$name> for $type {
+            fn eq(&self, rhs: &$name) -> bool {
+                rhs.0 == self
+            }
+        }
+
+        impl PartialEq<&$name> for $type {
+            fn eq(&self, rhs: &&$name) -> bool {
+                (*rhs).0 == self
+            }
+        }
+
+        impl PartialEq<$type> for $name {
+            fn eq(&self, rhs: &$type) -> bool {
+                self.0 == rhs
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, rhs: &str) -> bool {
+                self.0.as_str() == rhs
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, rhs: &&str) -> bool {
+                self.0.as_str() == *rhs
+            }
+        }
+    };
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum StringEnum<T> {
+    Known(T),
+    Unknown(Cow<'static, str>),
+}
+
+impl<T> PartialEq for StringEnum<T>
+where
+    T: Serialize + PartialEq,
+{
+    fn eq(&self, rhs: &Self) -> bool {
+        use StringEnum::{Known, Unknown};
+
+        match (self, rhs) {
+            (Known(a), Known(b)) => a == b,
+            (Known(_), Unknown(b)) => self.as_str() == b,
+            (Unknown(a), Known(_)) => a == rhs.as_str(),
+            (Unknown(_), Unknown(_)) => self.as_str() == rhs.as_str(),
+        }
+    }
+}
+
+impl<T> PartialEq<T> for StringEnum<T>
+where
+    T: Serialize + PartialEq,
+{
+    fn eq(&self, rhs: &T) -> bool {
+        use StringEnum::{Known, Unknown};
+
+        match self {
+            Known(value) => value == rhs,
+            Unknown(value) => value == VariantName::extract(rhs),
+        }
+    }
+}
+
+impl<T> PartialEq<&T> for StringEnum<T>
+where
+    T: Serialize + PartialEq,
+{
+    fn eq(&self, rhs: &&T) -> bool {
+        self == *rhs
+    }
+}
+
+impl<T> StringEnum<T>
+where
+    T: Serialize,
+{
+    pub fn new(variant: T) -> Self {
+        Self::Known(variant)
+    }
+
+    pub fn new_from_str<S>(value: S) -> Self
+    where
+        S: Into<Cow<'static, str>>,
+    {
+        Self::Unknown(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Known(value) => VariantName::extract(value),
+            Self::Unknown(value) => value.as_ref(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct VariantName;
+impl VariantName {
+    pub fn extract<T: Serialize>(value: &T) -> &'static str {
+        value.serialize(&mut VariantName).unwrap_or("unknown")
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("cannot extract name of variant")]
+struct VariantNameError;
+
+impl serde::ser::Error for VariantNameError {
+    fn custom<T: std::fmt::Display>(_msg: T) -> Self {
+        VariantNameError
+    }
+}
+
+struct TupleVariantName {
+    name: &'static str,
+}
+
+impl SerializeTupleVariant for TupleVariantName {
+    type Ok = &'static str;
+    type Error = VariantNameError;
+
+    fn serialize_field<T>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self.name)
+    }
+}
+
+impl<'a> Serializer for &'a mut VariantName {
+    type Ok = &'static str;
+    type Error = VariantNameError;
+
+    type SerializeSeq = Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = TupleVariantName;
+    type SerializeMap = Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(name)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(variant)
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Ok(name)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Ok(variant)
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Ok(TupleVariantName { name: variant })
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(VariantNameError)
+    }
+
+    fn collect_str<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized,
+    {
+        Err(VariantNameError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub enum LazuLight {
+        #[serde(rename = "DaPomky")]
+        Pomu,
+        Elira,
+        Finana,
+    }
+
+    define_string_enum!(Nijisanji, LazuLight);
+
+    #[test]
+    fn from() {
+        assert_eq!(
+            Nijisanji::new(LazuLight::Pomu),
+            Nijisanji::from(LazuLight::Pomu)
+        );
+    }
+
+    #[test]
+    fn partial_eq() -> Result {
+        // Wrapper struct equality
+        assert_eq!(
+            Nijisanji::new(LazuLight::Pomu),
+            Nijisanji::new(LazuLight::Pomu),
+        );
+
+        assert_ne!(
+            Nijisanji::new(LazuLight::Pomu),
+            Nijisanji::new(LazuLight::Elira),
+        );
+
+        // Equality between wrapper struct and unwrapped struct
+        assert_eq!(Nijisanji::new(LazuLight::Pomu), LazuLight::Pomu);
+
+        assert_eq!(LazuLight::Pomu, Nijisanji::new(LazuLight::Pomu));
+
+        assert_ne!(Nijisanji::new(LazuLight::Pomu), LazuLight::Finana);
+
+        assert_ne!(LazuLight::Pomu, Nijisanji::new(LazuLight::Finana));
+
+        // Equality between wrapper struct and raw string, renamed
+        assert_eq!(Nijisanji::new(LazuLight::Pomu), "DaPomky");
+        assert_ne!(Nijisanji::new(LazuLight::Pomu), "Pomu");
+
+        // Equality between wrapper struct constructed different ways
+        assert_eq!(
+            Nijisanji::new_from_str("DaPomky"),
+            Nijisanji::new(LazuLight::Pomu),
+        );
+
+        assert_eq!(
+            Nijisanji::new(LazuLight::Pomu),
+            Nijisanji::new_from_str("DaPomky"),
+        );
+
+        assert_eq!(
+            Nijisanji::new_from_str("DaPomky"),
+            Nijisanji::new_from_str("DaPomky"),
+        );
+
+        // Equality of `as_str`
+        assert_eq!(Nijisanji::new(LazuLight::Elira).as_str(), "Elira");
+
+        // Allow creation of custom values
+        assert_eq!(
+            Nijisanji::new_from_str("Petra"),
+            Nijisanji::new_from_str("Petra"),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn serialize() -> Result {
+        assert_eq!(
+            serde_json::to_value(Nijisanji::new(LazuLight::Pomu))?,
+            json!("DaPomky"),
+        );
+
+        assert_eq!(
+            serde_json::to_value(Nijisanji::new_from_str("DaPomky"))?,
+            json!("DaPomky"),
+        );
+
+        assert_eq!(
+            serde_json::to_value(Nijisanji::new_from_str("Oliver"))?,
+            json!("Oliver"),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize() -> Result {
+        assert_eq!(
+            serde_json::from_value::<Nijisanji>(json!("DaPomky"))?,
+            Nijisanji::new(LazuLight::Pomu),
+        );
+
+        assert_eq!(
+            serde_json::from_value::<Nijisanji>(json!("DaPomky"))?,
+            Nijisanji::new_from_str("DaPomky"),
+        );
+
+        assert_eq!(
+            serde_json::from_value::<Nijisanji>(json!("Oliver"))?,
+            Nijisanji::new_from_str("Oliver"),
+        );
+
+        Ok(())
+    }
+}

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -13,11 +13,6 @@ macro_rules! define_string_enum {
         pub struct $name(crate::enumeration::StringEnum<$type>);
 
         impl $name {
-            /// Returns the string representation.
-            pub fn as_str(&self) -> &str {
-                self.0.as_str()
-            }
-
             /// Creates a new value from a known variant.
             pub const fn new(variant: $type) -> Self {
                 Self(crate::enumeration::StringEnum::Known(variant))
@@ -36,6 +31,11 @@ macro_rules! define_string_enum {
                 Self(crate::enumeration::StringEnum::Unknown(
                     std::borrow::Cow::Borrowed(value),
                 ))
+            }
+
+            /// Returns the string representation.
+            pub fn as_str(&self) -> &str {
+                self.0.as_str()
             }
         }
 

--- a/src/enumeration.rs
+++ b/src/enumeration.rs
@@ -2,6 +2,8 @@ use serde::ser::{Impossible, SerializeTupleVariant};
 use serde::{Deserialize, Serialize, Serializer};
 use std::borrow::Cow;
 
+// Define a wrapper struct around `StringEnum` allowing for serializing/deserializing from a known
+// set of variants, and also arbitrary string values.
 macro_rules! define_string_enum {
     (
         $(#[$meta:meta])*
@@ -97,9 +99,11 @@ macro_rules! define_string_enum {
 
 pub(crate) use define_string_enum;
 
+// Helper enum for allowing serde deserialization to retain unknown values, and serialize arbitrary
+// string values for enums. This is meant to be used inside the `define_string_enum` macro.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum StringEnum<T> {
+pub(crate) enum StringEnum<T> {
     Known(T),
     Unknown(Cow<'static, str>),
 }
@@ -200,6 +204,7 @@ impl SerializeTupleVariant for TupleVariantName {
     }
 }
 
+// Verbose serializer implementation that just extracts the enum variant name.
 impl<'a> Serializer for &'a mut VariantName {
     type Ok = &'static str;
     type Error = VariantNameError;

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use futures_core::TryStream;
 use futures_sink::Sink;
 use std::error::Error as StdError;
 
-pub use crate::data::{ApiError, ResponseType};
+pub use crate::data::{ApiError, ArbitraryResponseType};
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn StdError + Send + Sync>;
@@ -49,9 +49,9 @@ pub enum ErrorKind {
 #[error("received unexpected response (expected {expected}, received {received})")]
 pub struct UnexpectedResponseError {
     /// The expected response type.
-    pub expected: ResponseType,
+    pub expected: ArbitraryResponseType,
     /// The received response type.
-    pub received: ResponseType,
+    pub received: ArbitraryResponseType,
 }
 
 impl From<serde_json::Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use futures_core::TryStream;
 use futures_sink::Sink;
 use std::error::Error as StdError;
 
-pub use crate::data::{ApiError, ArbitraryResponseType};
+pub use crate::data::{ApiError, GenericResponseType};
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn StdError + Send + Sync>;
@@ -49,9 +49,9 @@ pub enum ErrorKind {
 #[error("received unexpected response (expected {expected}, received {received})")]
 pub struct UnexpectedResponseError {
     /// The expected response type.
-    pub expected: ArbitraryResponseType,
+    pub expected: GenericResponseType,
     /// The received response type.
-    pub received: ArbitraryResponseType,
+    pub received: GenericResponseType,
 }
 
 impl From<serde_json::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ pub mod data;
 /// Types related to error handling.
 pub mod error;
 
+// Internal helpers for generating enums
 pub(crate) mod enumeration;
 
 // Macro for enabling `doc_cfg` on docs.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,8 @@ pub mod data;
 /// Types related to error handling.
 pub mod error;
 
+pub(crate) mod enumeration;
+
 // Macro for enabling `doc_cfg` on docs.rs
 macro_rules! cfg_feature {
     (


### PR DESCRIPTION
The previous approach in #19 had an issue where users could potentially
pattern match the `Other` variant and bypass the `PartialEq` checks for
ensuring the types were the same.

This PR removes the fallback variant of the request/response type enums
and instead adds a layer of indirection to disallow the user from
directly pattern matching the variant. It also makes it less verbose
to add support for similar enums (e.g., the hotkey types) in later PRs.