### PR TITLE
Use newtype wrapper for request ID

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -4,7 +4,7 @@ mod error_id;
 
 pub use crate::data::enumeration::EnumString;
 pub use crate::data::envelope::{
-    RequestEnvelope, ResponseData, ResponseEnvelope, API_NAME, API_VERSION,
+    RequestEnvelope, RequestId, ResponseData, ResponseEnvelope, API_NAME, API_VERSION,
 };
 pub use crate::data::error_id::ErrorId;
 

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -1,4 +1,4 @@
-use crate::data::{RequestEnvelope, ResponseEnvelope};
+use crate::data::{RequestEnvelope, RequestId, ResponseEnvelope};
 use crate::error::{BoxError, Error};
 
 use futures_core::TryStream;
@@ -22,10 +22,10 @@ crate::cfg_feature! {
 pub struct IdTagger(usize);
 
 impl TagStore<RequestEnvelope, ResponseEnvelope> for IdTagger {
-    type Tag = String;
+    type Tag = RequestId;
 
     fn assign_tag(mut self: Pin<&mut Self>, request: &mut RequestEnvelope) -> Self::Tag {
-        let id = self.0.to_string();
+        let id = RequestId::from(self.0.to_string());
         request.request_id = Some(id.clone());
         self.0 += 1;
         id


### PR DESCRIPTION
Could be used for optimizations in the future to prevent breaking changes, but
for now it's just a plain wrapper.