### PR TITLE
Use `smol_str` for request ID strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ paste = "1"
 pin-project-lite = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
+smol_str = { version = "0.1", features = ["serde"] }
 thiserror = "1"
 tokio = "1"
 tokio-tower = "0.6"

--- a/src/data/envelope.rs
+++ b/src/data/envelope.rs
@@ -19,29 +19,29 @@ pub const API_VERSION: &'static str = "1.0";
 ///
 /// This is a newtype wrapper rather than a plain `String` to allow for possible optimizations to
 /// the internal representation (using types optimized for small strings, etc).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RequestId(String);
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestId(smol_str::SmolStr);
 
 impl RequestId {
     /// Creates a new [`RequestId`].
     pub fn new(value: String) -> Self {
-        Self(value)
+        Self(value.into())
     }
 
     /// Returns the string representation of the request ID.
     pub fn as_str(&self) -> &str {
-        self.0.as_ref()
+        self.0.as_str()
     }
 
     /// Consumes this value and returns the inner `String` representation.
     pub fn into_string(self) -> String {
-        self.0
+        String::from(self.0)
     }
 }
 
 impl From<String> for RequestId {
     fn from(value: String) -> Self {
-        Self(value)
+        Self(value.into())
     }
 }
 
@@ -331,7 +331,7 @@ impl Default for ResponseEnvelope {
             api_name: API_NAME.into(),
             api_version: API_VERSION.into(),
             timestamp: 0,
-            request_id: RequestId("".to_owned()),
+            request_id: RequestId::default(),
             data: Ok(ResponseData {
                 message_type: EnumString::const_new_from_str("UnknownResponse"),
                 data: OpaqueValue::default(),

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -30,7 +30,8 @@ impl TagStore<RequestEnvelope, ResponseEnvelope> for IdTagger {
 
     fn assign_tag(mut self: Pin<&mut Self>, request: &mut RequestEnvelope) -> Self::Tag {
         let id = self.next;
-        if let Err(_) = write!(self.buffer, "{}", id) {
+        if write!(self.buffer, "{}", id).is_err() {
+            // We don't expect this to happen, but recover just in case
             self.buffer = id.to_string();
         }
 

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -4,7 +4,6 @@ use crate::data::{
 use crate::error::Error;
 use crate::service::send_request;
 
-use futures_util::TryFutureExt;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -211,14 +210,7 @@ where
         let mut this = self.clone();
 
         let f = async move {
-            let resp = this
-                .service
-                .ready()
-                .await
-                .map_err(Error::from)?
-                .call(req)
-                .map_err(Error::from)
-                .await?;
+            let resp = this.service.ready().await?.call(req).await?;
 
             if !resp.is_unauthenticated_error() {
                 return Ok(ResponseWithToken::new(resp));


### PR DESCRIPTION
Typically request IDs will be short strings, so we can use an inline
string type optimized for these kinds of cases.