### PR TITLE
If request ID is specified on input, preserve it

### DIFF
--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -29,6 +29,11 @@ impl TagStore<RequestEnvelope, ResponseEnvelope> for IdTagger {
     type Tag = RequestId;
 
     fn assign_tag(mut self: Pin<&mut Self>, request: &mut RequestEnvelope) -> Self::Tag {
+        // If request already has an ID, use it. Otherwise generate a new one.
+        if let Some(id) = &request.request_id {
+            return id.clone();
+        }
+
         let id = self.next;
         if write!(self.buffer, "{}", id).is_err() {
             // We don't expect this to happen, but recover just in case


### PR DESCRIPTION
If a user wants to send `RequestEnvelope`s directly (without going
through the `Client`), the underlying service layer should preserve the
original request ID if it's set, rather than always generating a new
one.