### PR TITLE
Fix serialization of `jeb_` field 

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -603,10 +603,15 @@ impl Default for ColorTint {
 #[serde(rename_all = "camelCase")]
 pub struct ArtMeshMatcher {
     pub tint_all: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub art_mesh_number: Vec<i32>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub name_exact: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub name_contains: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tag_exact: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tag_contains: Vec<String>,
 }
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -580,6 +580,7 @@ pub struct ColorTint {
     pub color_a: u8,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mix_with_scene_lighting_color: Option<f64>,
+    #[serde(rename = "jeb_")]
     pub jeb_: bool,
 }
 


### PR DESCRIPTION
This field requires a manual `rename` since the `camelCase` renamer
attribute on the struct ends up removing the trailing underscore.

Also avoids serializing empty arrays in `ArtMeshMatcher`.