### PR TITLE
Add `into_inner` methods for service wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vtubestudio"
-version = "0.3.3-alpha.0"
+version = "0.4.0-alpha.0"
 edition = "2018"
 authors = ["Walfie <walfington@gmail.com"]
 license = "MIT"

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -632,6 +632,7 @@ pub struct CapturePart {
 #[serde(rename_all = "camelCase")]
 pub struct Parameter {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub added_by: Option<String>,
     pub value: f64,
     pub min: f64,

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -90,6 +90,13 @@ where
     }
 }
 
+impl<S> Authentication<S> {
+    /// Consumes `self`, returning the inner service.
+    pub fn into_inner(self) -> S {
+        self.service
+    }
+}
+
 impl<S> fmt::Debug for Authentication<S>
 where
     S: fmt::Debug,

--- a/src/service/maker.rs
+++ b/src/service/maker.rs
@@ -33,6 +33,13 @@ where
     }
 }
 
+impl<M, R> MakeApiService<M, R> {
+    /// Consumes `self`, returning the inner service.
+    pub fn into_inner(self) -> M {
+        self.maker
+    }
+}
+
 impl<M, R> Service<R> for MakeApiService<M, R>
 where
     M: MakeTransport<R, RequestEnvelope, Item = ResponseEnvelope> + Send,

--- a/src/transport/api.rs
+++ b/src/transport/api.rs
@@ -53,6 +53,13 @@ where
     }
 }
 
+impl<T, C> ApiTransport<T, C> {
+    /// Consumes `self`, returning the inner transport.
+    pub fn into_inner(self) -> T {
+        self.transport
+    }
+}
+
 impl<T, C> Sink<RequestEnvelope> for ApiTransport<T, C>
 where
     T: Sink<C::Output>,


### PR DESCRIPTION
Unfortunately couldn't add one for `ApiService` since the underlying
`tokio_tower` multiplex client doesn't have a similar method.