### PR TITLE
Attempt to authenticate on initial connection

### DIFF
--- a/src/data/envelope.rs
+++ b/src/data/envelope.rs
@@ -261,7 +261,7 @@ impl<'de> Deserialize<'de> for ResponseEnvelope {
             })
         };
 
-        // Typically this will be "VTubeStudioPublicAPI, so we can possibly avoid allocating
+        // Typically this will be "VTubeStudioPublicAPI", so we can possibly avoid allocating
         let api_name = if raw.api_name == API_NAME {
             Cow::Borrowed(API_NAME)
         } else {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -293,7 +293,6 @@ define_request_response_pairs!(
         },
     },
 
-
     {
         rust_name = MoveModel,
         /// Moving the currently loaded VTS model.

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,27 +67,6 @@ impl UnexpectedResponseError {
     }
 }
 
-/// Authentication token is invalid or has been revoked by the user.
-///
-/// This error is returned from the [`Authentication`](crate::service::Authentication) service when
-/// `authenticated` is false in an [`AuthenticationResponse`](crate::data::AuthenticationResponse).
-#[derive(thiserror::Error, Debug, Clone, PartialEq)]
-#[error("{reason}")]
-pub struct InvalidTokenError {
-    pub(crate) reason: String,
-}
-
-impl InvalidTokenError {
-    pub(crate) fn new(reason: String) -> Self {
-        Self { reason }
-    }
-
-    /// The reason for the error.
-    pub fn reason(&self) -> &str {
-        self.reason.as_str()
-    }
-}
-
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
         Self::new(ErrorKind::Json).with_source(error)
@@ -103,12 +82,6 @@ impl From<ApiError> for Error {
 impl From<UnexpectedResponseError> for Error {
     fn from(error: UnexpectedResponseError) -> Self {
         Self::new(ErrorKind::UnexpectedResponse).with_source(error)
-    }
-}
-
-impl From<InvalidTokenError> for Error {
-    fn from(error: InvalidTokenError) -> Self {
-        Self::new(ErrorKind::InvalidToken).with_source(error)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,8 +33,6 @@ pub enum ErrorKind {
     ConnectionDropped,
     /// received unexpected response from server
     UnexpectedResponse,
-    /// the provided authentication token was invalid
-    InvalidToken,
     /// received server response with unexpected request ID
     Desynchronized,
     /// JSON error

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,8 @@ use futures_core::TryStream;
 use futures_sink::Sink;
 use std::error::Error as StdError;
 
-pub use crate::data::{ApiError, EnumString, ErrorId, ResponseType};
+use crate::data::ResponseType;
+pub use crate::data::{ApiError, EnumString, ErrorId};
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn StdError + Send + Sync>;

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -71,7 +71,7 @@ where
 /// * encountering a disconnection error
 /// * receiving an auth error from the API
 ///
-/// If no stored token is availble, or the token is invalid, it will request a new auth token by
+/// If no stored token is available, or the token is invalid, it will request a new auth token by
 /// sending an [`AuthenticationTokenRequest`] (which will require the user to accept the pop-up in
 /// the VTube Studio app).
 #[derive(Clone)]

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -204,16 +204,21 @@ where
                     *self.token.lock().unwrap() = maybe_token.clone();
                 }
 
-                self.is_authenticated.store(true, Ordering::Relaxed);
+                self.set_authentication_status(true);
                 maybe_token
             }
             Err(e) => {
-                self.is_authenticated.store(false, Ordering::Relaxed);
+                self.set_authentication_status(false);
                 return Err(e);
             }
         };
 
         Ok(new_token)
+    }
+
+    fn set_authentication_status(&mut self, is_authenticated: bool) {
+        self.is_authenticated
+            .store(is_authenticated, Ordering::Relaxed);
     }
 }
 
@@ -249,7 +254,7 @@ where
                 Err(e) => {
                     let error = Error::from(e);
                     if error.has_kind(ErrorKind::ConnectionDropped) {
-                        this.is_authenticated.store(false, Ordering::Relaxed);
+                        this.set_authentication_status(false);
                     }
                     return Err(error);
                 }


### PR DESCRIPTION
Previously the `Authentication` service would only try to authenticate
on receiving an auth error. This commit updates it to authenticate after
initial connection and also after detecting a dropped connection.

Some public fields/functions have been made private since they're
internal implementation details, to avoid having to do breaking changes
in future refactors like this.