### PR TITLE
Change type of `color_overlay_{r,g,b}` fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vtubestudio"
-version = "0.4.1-alpha.0"
+version = "0.5.0-alpha.0"
 edition = "2018"
 authors = ["Walfie <walfington@gmail.com"]
 license = "MIT"

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -461,11 +461,11 @@ define_request_response_pairs!(
             /// Smoothing.(between 0 and 60).
             pub smoothing: i32,
             /// The red component of the overlay (between 0 and 459).
-            pub color_overlay_r: u8,
+            pub color_overlay_r: i32,
             /// The green component of the overlay (between 0 and 459).
-            pub color_overlay_g: u8,
+            pub color_overlay_g: i32,
             /// The blue component of the overlay (between 0 and 459).
-            pub color_overlay_b: u8,
+            pub color_overlay_b: i32,
             /// The average red component of the overlay.
             pub color_avg_r: u8,
             /// The average green component of the overlay.


### PR DESCRIPTION
I mistakenly set them to `u8` thinking the values would be between 0 and
255. According to the docs, they can go up to 459:

> This may produce values as high as 2 * 255 for R, G and B. The values
> are capped at 1.8 * 255 = 459.

While `u16` might be a tighter fit in terms of the number range, setting
them to `i32` allows for more flexibility.