### PR TITLE
Add new message types (up to date as of v1.21.11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vtubestudio"
-version = "0.6.2-alpha.0"
+version = "0.7.0-alpha.0"
 edition = "2018"
 authors = ["Walfie <walfington@gmail.com"]
 license = "MIT"

--- a/examples/hotkey.rs
+++ b/examples/hotkey.rs
@@ -16,7 +16,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         let resp = client
-            .send(&HotkeysInCurrentModelRequest { model_id: None })
+            .send(&HotkeysInCurrentModelRequest {
+                model_id: None,
+                live2d_item_file_name: None,
+            })
             .await?;
 
         if resp.available_hotkeys.len() == 0 {
@@ -49,6 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     client
                         .send(&HotkeyTriggerRequest {
                             hotkey_id: hotkey.hotkey_id.clone(),
+                            item_instance_id: None,
                         })
                         .await?;
                 }

--- a/src/data/error_id.rs
+++ b/src/data/error_id.rs
@@ -135,8 +135,8 @@ define_error_ids! {
     (204, HOTKEY_ID_FOUND_BUT_HOTKEY_DATA_INVALID, HotkeyIDFoundButHotkeyDataInvalid),
     (205, HOTKEY_EXECUTION_FAILED_BECAUSE_BAD_STATE, HotkeyExecutionFailedBecauseBadState),
     (206, HOTKEY_UNKNOWN_EXECUTION_FAILURE, HotkeyUnknownExecutionFailure),
-    (207, HOTKEY_EXECUTION_FAILED_BECAUSE_LIVE2_D_ITEM_NOT_FOUND, HotkeyExecutionFailedBecauseLive2DItemNotFound),
-    (208, HOTKEY_EXECUTION_FAILED_BECAUSE_LIVE2_D_ITEMS_DO_NOT_SUPPORT_THIS_HOTKEY_TYPE, HotkeyExecutionFailedBecauseLive2DItemsDoNotSupportThisHotkeyType),
+    (207, HOTKEY_EXECUTION_FAILED_BECAUSE_LIVE2D_ITEM_NOT_FOUND, HotkeyExecutionFailedBecauseLive2DItemNotFound),
+    (208, HOTKEY_EXECUTION_FAILED_BECAUSE_LIVE2D_ITEMS_DO_NOT_SUPPORT_THIS_HOTKEY_TYPE, HotkeyExecutionFailedBecauseLive2DItemsDoNotSupportThisHotkeyType),
 
     // Errors related to ColorTintRequest
     (250, COLOR_TINT_REQUEST_NO_MODEL_LOADED, ColorTintRequestNoModelLoaded),

--- a/src/data/error_id.rs
+++ b/src/data/error_id.rs
@@ -135,6 +135,8 @@ define_error_ids! {
     (204, HOTKEY_ID_FOUND_BUT_HOTKEY_DATA_INVALID, HotkeyIDFoundButHotkeyDataInvalid),
     (205, HOTKEY_EXECUTION_FAILED_BECAUSE_BAD_STATE, HotkeyExecutionFailedBecauseBadState),
     (206, HOTKEY_UNKNOWN_EXECUTION_FAILURE, HotkeyUnknownExecutionFailure),
+    (207, HOTKEY_EXECUTION_FAILED_BECAUSE_LIVE2_D_ITEM_NOT_FOUND, HotkeyExecutionFailedBecauseLive2DItemNotFound),
+    (208, HOTKEY_EXECUTION_FAILED_BECAUSE_LIVE2_D_ITEMS_DO_NOT_SUPPORT_THIS_HOTKEY_TYPE, HotkeyExecutionFailedBecauseLive2DItemsDoNotSupportThisHotkeyType),
 
     // Errors related to ColorTintRequest
     (250, COLOR_TINT_REQUEST_NO_MODEL_LOADED, ColorTintRequestNoModelLoaded),
@@ -167,6 +169,7 @@ define_error_ids! {
     (452, INJECT_DATA_WEIGHT_INVALID, InjectDataWeightInvalid),
     (453, INJECT_DATA_PARAM_NAME_NOT_FOUND, InjectDataParamNameNotFound),
     (454, INJECT_DATA_PARAM_CONTROLLED_BY_OTHER_PLUGIN, InjectDataParamControlledByOtherPlugin),
+    (455, INJECT_DATA_MODE_UNKNOWN, InjectDataModeUnknown),
 
     // Errors related to ParameterValueRequest
     (500, PARAMETER_VALUE_REQUEST_PARAMETER_NOT_FOUND, ParameterValueRequestParameterNotFound),
@@ -192,4 +195,37 @@ define_error_ids! {
     (704, SET_CURRENT_MODEL_PHYSICS_REQUEST_PHYSICS_GROUP_ID_NOT_FOUND, SetCurrentModelPhysicsRequestPhysicsGroupIDNotFound),
     (705, SET_CURRENT_MODEL_PHYSICS_REQUEST_NO_OVERRIDE_VALUE_PROVIDED, SetCurrentModelPhysicsRequestNoOverrideValueProvided),
     (706, SET_CURRENT_MODEL_PHYSICS_REQUEST_DUPLICATE_PHYSICS_GROUP_ID, SetCurrentModelPhysicsRequestDuplicatePhysicsGroupID),
+
+    // Errors related to ItemLoadRequest
+    (750, ITEM_FILE_NAME_MISSING, ItemFileNameMissing),
+    (751, ITEM_FILE_NAME_NOT_FOUND, ItemFileNameNotFound),
+    (752, ITEM_LOAD_LOAD_COOLDOWN_NOT_OVER, ItemLoadLoadCooldownNotOver),
+    (753, CANNOT_CURRENTLY_LOAD_ITEM, CannotCurrentlyLoadItem),
+    (754, CANNOT_LOAD_ITEM_SCENE_FULL, CannotLoadItemSceneFull),
+    (755, ITEM_ORDER_INVALID, ItemOrderInvalid),
+    (756, ITEM_ORDER_ALREADY_TAKEN, ItemOrderAlreadyTaken),
+    (757, ITEM_LOAD_VALUES_INVALID, ItemLoadValuesInvalid),
+
+    // Errors related to ItemUnloadRequest
+    (800, CANNOT_CURRENTLY_UNLOAD_ITEM, CannotCurrentlyUnloadItem),
+
+    // Errors related to ItemAnimationControlRequest
+    (850, ITEM_ANIMATION_CONTROL_INSTANCE_ID_NOT_FOUND, ItemAnimationControlInstanceIDNotFound),
+    (851, ITEM_ANIMATION_CONTROL_UNSUPPORTED_ITEM_TYPE, ItemAnimationControlUnsupportedItemType),
+    (852, ITEM_ANIMATION_CONTROL_AUTO_STOP_FRAMES_INVALID, ItemAnimationControlAutoStopFramesInvalid),
+    (853, ITEM_ANIMATION_CONTROL_TOO_MANY_AUTO_STOP_FRAMES, ItemAnimationControlTooManyAutoStopFrames),
+    (854, ITEM_ANIMATION_CONTROL_SIMPLE_IMAGE_DOES_NOT_SUPPORT_ANIM, ItemAnimationControlSimpleImageDoesNotSupportAnim),
+
+    // Errors related to ItemMoveRequest
+    (900, ITEM_MOVE_REQUEST_INSTANCE_ID_NOT_FOUND, ItemMoveRequestInstanceIDNotFound),
+    (901, ITEM_MOVE_REQUEST_INVALID_FADE_MODE, ItemMoveRequestInvalidFadeMode),
+    (902, ITEM_MOVE_REQUEST_ITEM_ORDER_TAKEN_OR_INVALID, ItemMoveRequestItemOrderTakenOrInvalid),
+    (903, ITEM_MOVE_REQUEST_CANNOT_CURRENTLY_CHANGE_ORDER, ItemMoveRequestCannotCurrentlyChangeOrder),
+
+    // Errors related to EventSubscriptionRequest
+    (950, EVENT_SUBSCRIPTION_REQUEST_EVENT_TYPE_UNKNOWN, EventSubscriptionRequestEventTypeUnknown),
+
+    // Event config errors
+    (100_000, EVENT_TEST_EVENT_TEST_MESSAGE_TOO_LONG, Event_TestEvent_TestMessageTooLong),
+    (100_050, EVENT_MODEL_LOADED_EVENT_MODEL_ID_INVALID, Event_ModelLoadedEvent_ModelIDInvalid),
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1077,7 +1077,8 @@ define_request_response_pairs!(
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 #[non_exhaustive]
-/// Known message types for [`EnumString<InjectParameterDataMode>`].
+/// Known message types for [`EnumString<InjectParameterDataMode>`] (used in
+/// [`InjectParameterDataRequest`]).
 pub enum InjectParameterDataMode {
     #[serde(rename = "set")]
     Set,
@@ -1094,7 +1095,7 @@ impl Default for InjectParameterDataMode {
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 #[non_exhaustive]
-/// Known message types for [`EnumString<ItemType>`].
+/// Known message types for [`EnumString<ItemType>`] (used in [`ItemInstanceInScene`]).
 pub enum ItemType {
     #[serde(rename = "PNG")]
     Png,
@@ -1182,7 +1183,7 @@ pub struct AvailableItemFile {
     pub loaded_count: i32,
 }
 
-/// Used in [`ItemMoveRequest`]
+/// Used in [`ItemMoveRequest`].
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ItemToMove {
@@ -1286,7 +1287,7 @@ where
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-/// Known message types for [`EnumString<FadeMode>`].
+/// Known message types for [`EnumString<FadeMode>`]. Used in [`ItemToMove`].
 pub enum FadeMode {
     Linear,
     EaseIn,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1114,7 +1114,7 @@ impl Default for ItemType {
     }
 }
 
-/// Used in [`UnloadItemResponse`].
+/// Used in [`ItemUnloadResponse`].
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UnloadedItem {
@@ -1125,7 +1125,7 @@ pub struct UnloadedItem {
     pub file_name: String,
 }
 
-/// Used in [`ItemInstancesInSceneResponse`].
+/// Used in [`ItemListResponse`].
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ItemInstanceInScene {
@@ -1169,7 +1169,7 @@ pub struct ItemInstanceInScene {
     pub from_workshop: bool,
 }
 
-/// Used in [`ItemInstancesInSceneResponse`].
+/// Used in [`ItemListResponse`].
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AvailableItemFile {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -926,6 +926,33 @@ define_request_response_pairs!(
             pub instance_id: String,
         },
     },
+
+    {
+        rust_name = ItemUnload,
+        /// Removing item from the scene.
+        ///
+        /// This may return an error of type `CannotCurrentlyUnloadItem` if the user currently has
+        /// menus open that prevent VTS from loading/unloading items.
+        req = {
+            /// Whether to unload all items in the scene.
+            pub unload_all_in_scene: bool,
+            /// Whether to unload all items loaded by this plugin.
+            pub unload_all_loaded_by_this_plugin: bool,
+            /// Whether to allow unloading items that have been loaded by the user or other
+            /// plugins.
+            pub allow_unloading_items_loaded_by_user_or_other_plugins: bool,
+            /// Request specific instance IDs to be unloaded.
+            #[serde(rename = "instanceIDs")]
+            pub instance_ids: Vec<String>,
+            /// Request specific file names to be unloaded.
+            pub file_names: Vec<String>,
+        },
+        /// Items unloaded successfully.
+        resp = {
+            /// List of unloaded items.
+            pub unloaded_items: Vec<UnloadedItem>,
+        },
+    },
 );
 
 #[allow(missing_docs)]
@@ -966,6 +993,17 @@ impl Default for ItemType {
     fn default() -> Self {
         Self::Unknown
     }
+}
+
+/// Used in [`UnloadItemResponse`].
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnloadedItem {
+    /// Instance ID.
+    #[serde(rename = "instanceID")]
+    pub instance_id: String,
+    /// File name.
+    pub file_name: String,
 }
 
 /// Used in [`ItemInstancesInSceneResponse`].

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -724,10 +724,10 @@ define_request_response_pairs!(
             pub use_custom_resolution: bool,
             /// The NDI width.
             #[serde(rename = "customWidthNDI")]
-            pub custom_width_ndi: i64,
+            pub custom_width_ndi: i32,
             /// The NDI height.
             #[serde(rename = "customHeightNDI")]
-            pub custom_height_ndi: i64,
+            pub custom_height_ndi: i32,
         },
     },
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -626,7 +626,7 @@ define_request_response_pairs!(
             /// aren't used in that case. Any number of plugins can use the `add` mode for a given
             /// parameter at the same time. This can be useful for bonk/throwing type plugins and
             /// other use-cases.
-            pub mode: EnumString<InjectParameterDataMode>,
+            pub mode: Option<EnumString<InjectParameterDataMode>>,
         },
         /// Empty response on parameter injection success.
         resp = {},

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -897,6 +897,8 @@ define_request_response_pairs!(
             /// Y position.
             pub position_y: f64,
             /// Item size. Should be between `0` and `1`.
+            ///
+            /// `0.32` is roughly the "default" size that items will have when the user loads them manually.
             pub size: f64,
             /// Rotation, in degrees.
             pub rotation: i32,
@@ -968,15 +970,19 @@ define_request_response_pairs!(
             #[serde(rename = "itemInstanceID")]
             pub item_instance_id: String,
             /// Frame rate for animated items, clamped between `0.1` and `120`.
+            #[serde(skip_serializing_if = "Option::is_none")]
             pub framerate: Option<f64>,
             /// Jump to a specific frame, zero-indexed.
             ///
             /// May return an error if the frame index is invalid, or if the item type does not
             /// support animation.
+            #[serde(skip_serializing_if = "Option::is_none")]
             pub frame: Option<i32>,
             /// Brightness.
+            #[serde(skip_serializing_if = "Option::is_none")]
             pub brightness: Option<f64>,
             /// Opacity.
+            #[serde(skip_serializing_if = "Option::is_none")]
             pub opacity: Option<f64>,
             /// Whether to set auto-stop frames.
             pub set_auto_stop_frames: bool,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1018,6 +1018,54 @@ define_request_response_pairs!(
             pub moved_items: Vec<MovedItem>,
         },
     },
+
+    {
+        rust_name = ArtMeshSelection,
+        /// Asking user to select ArtMeshes.
+        ///
+        /// You can use this request to show a list in VTube Studio containing all ArtMeshes of the
+        /// currently loaded main Live2D model and have the user select one or more of them. Once
+        /// the user is done selecting ArtMeshes, the ArtMesh IDs will be returned. You can use
+        /// those ArtMesh IDs in various other API requests, for example to apply a color tint to
+        /// them or make them invisible.
+        ///
+        /// If no model is currently loaded or there are currently other windows open, the request
+        /// will return an error.
+        ///
+        /// The user can hover over ArtMeshes to show their ID and click them to filter the shown
+        /// list for all ArtMeshes under on the click position.
+        req = {
+            /// This text is shown over the ArtMesh selection list.
+            ///
+            /// Must be between 4 and 1024 characters long, otherwise the default will be used.
+            pub text_override: Option<String>,
+            /// This text is shown when the user presses the `?` button.
+            ///
+            /// Must be between 4 and 1024 characters long, otherwise the default will be used.
+            pub help_override: Option<String>,
+            /// How many art meshes must be selected by the user.
+            ///
+            /// The "OK" button will be unavailable until exactly this many ArtMeshes are
+            /// activated. If you set this to 0 or lower, the user will be asked to choose any
+            /// arbitrary number of ArtMeshes (but at least one).
+            pub requested_art_mesh_count: i32,
+            /// List of ArtMeshes to be pre-selected.
+            ///
+            /// If any of these IDs are not contained in the current model, an error will be
+            /// returned.
+            pub active_art_meshes: Vec<String>,
+        },
+        /// ArtMesh selection response.
+        resp = {
+            /// This will be `true` if the user clicked "OK", and `false` if the user clicked
+            /// "Cancel".
+            pub success: bool,
+            /// ArtMeshes that were selected.
+            pub active_art_meshes: Vec<String>,
+            /// ArtMeshes that were not selected.
+            pub inactive_art_meshes: Vec<String>,
+        },
+    },
 );
 
 #[allow(missing_docs)]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -953,6 +953,57 @@ define_request_response_pairs!(
             pub unloaded_items: Vec<UnloadedItem>,
         },
     },
+
+    {
+        rust_name = ItemAnimationControl,
+        /// Controling items and item animations.
+        ///
+        /// You can control certain aspects of items in the scene. This request allows you to make
+        /// items darker (black overlay), change the opacity, and control the animation of animated
+        /// items. This request does not work with Live2D items and will return an error of type
+        /// `ItemAnimationControlUnsupportedItemType` if you try. This can be useful for "reactive
+        /// PNG"-type plugins and more.
+        req = {
+            /// Item instance ID.
+            #[serde(rename = "itemInstanceID")]
+            pub item_instance_id: String,
+            /// Frame rate for animated items, clamped between `0.1` and `120`.
+            pub framerate: Option<f64>,
+            /// Jump to a specific frame, zero-indexed.
+            ///
+            /// May return an error if the frame index is invalid, or if the item type does not
+            /// support animation.
+            pub frame: Option<i32>,
+            /// Brightness.
+            pub brightness: Option<f64>,
+            /// Opacity.
+            pub opacity: Option<f64>,
+            /// Whether to set auto-stop frames.
+            pub set_auto_stop_frames: bool,
+            /// List of frame indices that the animation will automatically stop playing on.
+            ///
+            /// Once the animation reaches one of those frames, it will stop playing and can only
+            /// be started again via the API using this request to set the animation play state to
+            /// `true`.
+            ///
+            /// This only takes effect if `set_auto_stop_frames` is `true`. You can have a maximum
+            /// of 1024 auto-stop frames.
+            pub auto_stop_frames: Vec<i32>,
+            /// Whether to set the animation play state.
+            pub set_animation_play_state: bool,
+            /// The animation play state (set to `false` to stop the animation).
+            ///
+            /// This only takes effect if `set_animation_play_state` is `true`.
+            pub animation_play_state: bool,
+        },
+        /// Item animation updated successfully.
+        resp = {
+            /// Current frame index.
+            pub frame: i32,
+            /// Whether the animation is playing (only relevant for animated items).
+            pub animation_playing: bool,
+        },
+    },
 );
 
 #[allow(missing_docs)]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -885,6 +885,47 @@ define_request_response_pairs!(
             pub available_item_files: Vec<AvailableItemFile>,
         },
     },
+
+    {
+        rust_name = ItemLoad,
+        /// Loading item into the scene.
+        req = {
+            /// File name. E.g., `some_item_name.jpg`.
+            pub file_name: String,
+            /// X position.
+            pub position_x: f64,
+            /// Y position.
+            pub position_y: f64,
+            /// Item size. Should be between `0` and `1`.
+            pub size: f64,
+            /// Rotation, in degrees.
+            pub rotation: i32,
+            /// Fade time, in seconds. Should be between `0` and `2`.
+            pub fade_time: f64,
+            /// Item order. If the order is taken, VTube Studio will automatically try to find the
+            /// next available order, unless `fail_if_order_taken` is `true`.
+            pub order: Option<i32>,
+            /// Set to `true` to fail with an `ItemOrderAlreadyTaken` error if the desired `order`
+            /// is already taken.
+            pub fail_if_order_taken: bool,
+            /// Smoothing, between `0` and `1`.
+            pub smoothing: f64,
+            /// Whether the item is censored.
+            pub censored: bool,
+            /// Whether the item is flipped.
+            pub flipped: bool,
+            /// Whether the item is locked.
+            pub locked: bool,
+            /// Unload item when plugin disconnects.
+            pub unload_when_plugin_disconnects: bool,
+        },
+        /// Item loaded successfully.
+        resp = {
+            /// Instance ID of the loaded item.
+            #[serde(rename = "instanceID")]
+            pub instance_id: String,
+        },
+    },
 );
 
 #[allow(missing_docs)]


### PR DESCRIPTION
Includes new fields for some existing messages, and adds these new messages:

* `ItemList{Request,Response}`
* `ItemLoad{Request,Response}`
* `ItemUnload{Request,Response}`
* `ItemAnimationControl{Request,Response}`
* `ItemMove{Request,Response}`
* `ArtMeshSelection{Request,Response}`

The last one is still in beta so it might change.